### PR TITLE
bug/can_not_retrieve_folder_when_anime_has_seasons

### DIFF
--- a/Jellyfin.Plugin.MyAnimeSync/Service/OnMarkedService.cs
+++ b/Jellyfin.Plugin.MyAnimeSync/Service/OnMarkedService.cs
@@ -67,7 +67,7 @@ namespace Jellyfin.Plugin.MyAnimeSync.Service
                 {
                     string serie = episode.SeriesName;
                     List<VirtualFolderInfo> virtualFolders = _libraryManager.GetVirtualFolders();
-                    Folder? folder = episode.GetParent().GetParent() as Folder;
+                    Folder? folder = episode.Series.GetParent() as Folder;
                     if (folder == null)
                     {
                         _logger.LogError(


### PR DESCRIPTION
Fixed a bug involving retrieving the wrong folder making it impossible to validate if the folder was checked or not.