### PR TITLE
bug/Anime_Name_Exceeding_Max_Search_Lenght

### DIFF
--- a/Jellyfin.Plugin.MyAnimeSync/Api/MALS/malApiHandler.cs
+++ b/Jellyfin.Plugin.MyAnimeSync/Api/MALS/malApiHandler.cs
@@ -214,9 +214,15 @@ namespace Jellyfin.Plugin.MyAnimeSync.Api.Mal
         {
             string token = uConfig.UserToken;
 
+            string searchString = animeName;
+            if (searchString.Length > 64)
+            {
+                searchString = searchString.Remove(64);
+            }
+
             var values = new Dictionary<string, string?>()
             {
-                { "q", animeName },
+                { "q", searchString },
                 { "limit", "25" },
                 { "fields", "alternative_titles" }
             };


### PR DESCRIPTION
Fix an issue where searching for anime with anime name exceeding 64 character returned invalid q, bad request.