### PR TITLE
bug/wrong_anime_info_when_anime_has_a_movie_has_a_sequel

### DIFF
--- a/Jellyfin.Plugin.MyAnimeSync/Api/MALS/JSONResponses.cs
+++ b/Jellyfin.Plugin.MyAnimeSync/Api/MALS/JSONResponses.cs
@@ -25,6 +25,18 @@ namespace Jellyfin.Plugin.MyAnimeSync.Api.Mal
     }
 
     /// <summary>
+    /// Structure for type of anime media.
+    /// </summary>
+    public static class MediaType
+    {
+        /// <summary>Seasonal Anime.</summary>
+        public const string SeasonalAnime = "tv";
+
+        /// <summary>Anime movie.</summary>
+        public const string Movie = "movie";
+    }
+
+    /// <summary>
     /// Json object respresenting a node.
     /// </summary>
     public class Node
@@ -76,6 +88,12 @@ namespace Jellyfin.Plugin.MyAnimeSync.Api.Mal
         /// </summary>
         [JsonPropertyName("title")]
         public string? Title { get; set; }
+
+        /// <summary>
+        /// Gets or sets the media type.
+        /// </summary>
+        [JsonPropertyName("media_type")]
+        public string? MediaType { get; set; }
 
         /// <summary>
         /// Gets or sets the amount of episode for the anime season.

--- a/Jellyfin.Plugin.MyAnimeSync/Api/MALS/malApiHandler.cs
+++ b/Jellyfin.Plugin.MyAnimeSync/Api/MALS/malApiHandler.cs
@@ -291,7 +291,7 @@ namespace Jellyfin.Plugin.MyAnimeSync.Api.Mal
 
             var values = new Dictionary<string, string?>()
             {
-                { "fields", "id,title,num_episodes,related_anime" }
+                { "fields", "id,title,media_type,num_episodes,related_anime" }
             };
 
             string url = AnimeUrl + "/" + animeID;

--- a/Jellyfin.Plugin.MyAnimeSync/Service/OnMarkedService.cs
+++ b/Jellyfin.Plugin.MyAnimeSync/Service/OnMarkedService.cs
@@ -140,12 +140,18 @@ namespace Jellyfin.Plugin.MyAnimeSync.Service
                     while (seasonOffset > 0)
                     {
                         info = await GetAnimeSequel(info, userConfig).ConfigureAwait(true);
-                        if (info == null || info.ID == null || info.EpisodeCount == null || info.Title == null)
+                        if (info == null || info.ID == null || info.EpisodeCount == null || info.Title == null || info.MediaType == null)
                         {
                             _logger.LogError(
                                 "Could not retrieve expected sequel using season offset for anime : {ID}",
                                 id);
                             return;
+                        }
+
+                        // Ignore anime movie for season offset.
+                        if (info.MediaType == MediaType.Movie)
+                        {
+                            continue;
                         }
 
                         Regex expression = new Regex(".*part ([0-9]+).*", RegexOptions.IgnoreCase);


### PR DESCRIPTION
Fix an issue where an anime episode number was wrong because anime movie were considered in season offset.