### PR TITLE
Feature/add fail update list and retry failed updates

### DIFF
--- a/Jellyfin.Plugin.MyAnimeSync/Api/MALS/Tasks/RetryFailedMalUpdatesTask.cs
+++ b/Jellyfin.Plugin.MyAnimeSync/Api/MALS/Tasks/RetryFailedMalUpdatesTask.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.MyAnimeSync.Configuration;
+using Jellyfin.Plugin.MyAnimeSync.Service;
+using MediaBrowser.Model.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.MyAnimeSync.Api.Mal.PluginTask
+{
+    /// <summary>
+    /// Task that update the token of all users.
+    /// This ScheduledTask prevent user token expiring before refreshing them in cases where the user does not watch animes for an extended period of time.
+    /// </summary>
+    public class RetryFailedMalUpdatesTask : IScheduledTask
+    {
+        private readonly ILogger<RetryFailedMalUpdatesTask> _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RetryFailedMalUpdatesTask"/> class.
+        /// </summary>
+        /// <param name="logger">Instance of the <see cref="ILogger{RetryFailedMalUpdatesTask}"/> interface.</param>
+        public RetryFailedMalUpdatesTask(ILogger<RetryFailedMalUpdatesTask> logger)
+        {
+            _logger = logger;
+        }
+
+        /// <inheritdoc/>
+        public string Name => "MyAnimeSync retry to update all failed entries.";
+
+        /// <inheritdoc/>
+        public string Key => "MyAnimeSyncMalRetryUpdates";
+
+        /// <inheritdoc/>
+        public string Description => "Retry to update user watched library for all failed entries";
+
+        /// <inheritdoc/>
+        public string Category => "MyAnimeSync";
+
+        /// <inheritdoc/>
+        public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
+        {
+            if (Plugin.Instance == null)
+            {
+                throw new DataException("Plugin instance was null!");
+            }
+
+            UserConfig[] configs = Plugin.Instance.Configuration.UserConfigs;
+
+            foreach (UserConfig uConfig in configs)
+            {
+                foreach (UpdateEntry entry in uConfig.FailedUpdates)
+                {
+                    if (entry.RetryCount < 5)
+                    {
+                        bool success = await OnMarkedService.UpdateAnimeList(entry.Serie, entry.EpisodeNumber, entry.SeasonNumber, uConfig, _logger).ConfigureAwait(true);
+                        if (!success)
+                        {
+                            uConfig.UpdateRetryFailed(entry);
+                        }
+                        else
+                        {
+                            uConfig.UpdateRetrySuccess(entry);
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        public IEnumerable<TaskTriggerInfo> GetDefaultTriggers()
+        {
+            var trigger = new TaskTriggerInfo
+            {
+                Type = TaskTriggerInfo.TriggerInterval,
+                IntervalTicks = TimeSpan.FromDays(1).Ticks
+            };
+
+            return new[] { trigger };
+        }
+    }
+}

--- a/Jellyfin.Plugin.MyAnimeSync/Configuration/UpdateEntry.cs
+++ b/Jellyfin.Plugin.MyAnimeSync/Configuration/UpdateEntry.cs
@@ -1,0 +1,54 @@
+namespace Jellyfin.Plugin.MyAnimeSync.Configuration
+{
+    /// <summary>
+    /// Update entry for failed updates.
+    /// </summary>
+    public class UpdateEntry
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UpdateEntry"/> class.
+        /// </summary>
+        private UpdateEntry()
+        {
+            Serie = string.Empty;
+            EpisodeNumber = 0;
+            SeasonNumber = 0;
+            RetryCount = 0;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UpdateEntry"/> class.
+        /// </summary>
+        /// <param name="serie">The serie's name.<see cref="string"/>.</param>
+        /// <param name="episodeNumber">The episode number.<see cref="int"/>.</param>
+        /// <param name="seasonNumber">The season number.<see cref="int"/>.</param>
+        /// <param name="retryCount">The amount of times we tried to update the user list.<see cref="int"/>.</param>
+        public UpdateEntry(string serie, int episodeNumber, int seasonNumber, int retryCount = 0)
+        {
+            Serie = serie;
+            EpisodeNumber = episodeNumber;
+            SeasonNumber = seasonNumber;
+            RetryCount = retryCount;
+        }
+
+        /// <summary>
+        /// Gets or sets the serie's name.
+        /// </summary>
+        public string Serie { get; set; }
+
+        /// <summary>
+        /// Gets or sets the episode number.
+        /// </summary>
+        public int EpisodeNumber { get; set; }
+
+        /// <summary>
+        /// Gets or sets the season number.
+        /// </summary>
+        public int SeasonNumber { get; set; }
+
+        /// <summary>
+        /// Gets or sets the retry count of the entry update.
+        /// </summary>
+        public int RetryCount { get; set; }
+    }
+}

--- a/Jellyfin.Plugin.MyAnimeSync/Configuration/UserConfig.cs
+++ b/Jellyfin.Plugin.MyAnimeSync/Configuration/UserConfig.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
-using Jellyfin.Data.Entities;
+using System.Linq;
+using J2N.Collections.Generic.Extensions;
 
 namespace Jellyfin.Plugin.MyAnimeSync.Configuration
 {
@@ -23,6 +24,7 @@ namespace Jellyfin.Plugin.MyAnimeSync.Configuration
             CodeChallenge = string.Empty;
             AllowNSFW = false;
             ListMonitoredLibraryGuid = Array.Empty<Guid>();
+            FailedUpdates = Array.Empty<UpdateEntry>();
         }
 
         /// <summary>
@@ -71,8 +73,70 @@ namespace Jellyfin.Plugin.MyAnimeSync.Configuration
         public Guid[] ListMonitoredLibraryGuid { get; set; }
 
         /// <summary>
+        /// Gets or sets the list of failed anime updates.
+        /// </summary>
+        public UpdateEntry[] FailedUpdates { get; set; }
+
+        /// <summary>
         /// Gets or sets user id.
         /// </summary>
         public Guid Id { get; set; }
+
+        /// <summary>
+        /// Update status for failed entries.
+        /// </summary>
+        /// <param name="serie">The serie's name.<see cref="string"/>.</param>
+        /// <param name="episodeNumber">The episode number.<see cref="int"/>.</param>
+        /// <param name="seasonNumber">The season number.<see cref="int"/>.</param>
+        /// <param name="retryCount">The amount of time we retried to update this entry.<see cref="int"/>.</param>
+        public void UpdateFailEntries(string serie, int episodeNumber, int seasonNumber, int retryCount = 0)
+        {
+            // Only retrieve result with same season number since different seasons are separate entries.
+            UpdateEntry? entry = FailedUpdates.FirstOrDefault<UpdateEntry>(item => item.Serie == serie && item.SeasonNumber == seasonNumber);
+            if (entry == null)
+            {
+                entry = new UpdateEntry(serie, episodeNumber, seasonNumber, retryCount);
+
+                List<UpdateEntry> tempList = FailedUpdates.ToList();
+                tempList.Add(entry);
+                FailedUpdates = tempList.ToArray();
+            }
+            else
+            {
+                if (entry.EpisodeNumber < episodeNumber)
+                {
+                    entry.EpisodeNumber = episodeNumber;
+                    retryCount = 0;
+                }
+                else if (retryCount > entry.RetryCount)
+                {
+                    entry.RetryCount = retryCount;
+                }
+            }
+
+            Plugin.Instance?.SaveConfiguration();
+        }
+
+        /// <summary>
+        /// Remove the entry from failed update list.
+        /// </summary>
+        /// <param name="entry">The season number.<see cref="UpdateEntry"/>.</param>
+        public void UpdateRetrySuccess(UpdateEntry entry)
+        {
+            List<UpdateEntry> tempList = FailedUpdates.ToList();
+            tempList.RemoveAll<UpdateEntry>(item => item.Serie == entry.Serie && item.SeasonNumber == entry.SeasonNumber);
+            FailedUpdates = tempList.ToArray();
+
+            Plugin.Instance?.SaveConfiguration();
+        }
+
+        /// <summary>
+        /// Update status for failed entries, this will increment retry count.
+        /// </summary>
+        /// <param name="entry">The serie's name.<see cref="UpdateEntry"/>.</param>
+        public void UpdateRetryFailed(UpdateEntry entry)
+        {
+            UpdateFailEntries(entry.Serie, entry.EpisodeNumber, entry.SeasonNumber, entry.RetryCount + 1);
+        }
     }
 }

--- a/Jellyfin.Plugin.MyAnimeSync/Configuration/UserConfig.cs
+++ b/Jellyfin.Plugin.MyAnimeSync/Configuration/UserConfig.cs
@@ -138,5 +138,16 @@ namespace Jellyfin.Plugin.MyAnimeSync.Configuration
         {
             UpdateFailEntries(entry.Serie, entry.EpisodeNumber, entry.SeasonNumber, entry.RetryCount + 1);
         }
+
+        /// <summary>
+        /// Retrieve the update entry.
+        /// </summary>
+        /// <param name="serie">The name of the serie.</param>
+        /// <param name="season">The season of the entrie.</param>
+        /// <returns>The update entry.</returns>
+        public UpdateEntry? GetUpdateEntry(string serie, int season)
+        {
+            return FailedUpdates.FirstOrDefault<UpdateEntry>(item => item.Serie == serie && item.SeasonNumber == season);
+        }
     }
 }

--- a/Jellyfin.Plugin.MyAnimeSync/Configuration/configPage.html
+++ b/Jellyfin.Plugin.MyAnimeSync/Configuration/configPage.html
@@ -60,6 +60,10 @@
                             <h3 class="checkboxListLabel">Checked Libraries:</h3>
                             <div id="CheckedLibraries" class="paperList checkboxList checkboxList-paperList"></div>
                         </div>
+                        <div>
+                            <h3 class="checkboxListLabel">Failed Anime Updates:</h3>
+                            <div id="FailedAnimeList" class="paperList checkboxList checkboxList-paperList"></div>
+                        </div>
                     </div>
                 </div>
                 <div>
@@ -134,6 +138,35 @@
                         div.appendChild(label);
                     }
                 })
+
+                var failedUpdateDiv = document.getElementById("FailedAnimeList");
+                failedUpdateDiv.innerHTML = "";
+                var div = document.createElement("div");
+                div.setAttribute("data-role", "controlgroup");
+                failedUpdateDiv.appendChild(div);
+                var result = userConfig.FailedUpdates;
+                for (var i = 0; i < result.length; i++)
+                {
+                    var label = document.createElement("label");
+                    var span = document.createElement("span");
+                    span.style.marginRight = "10px";
+                    span.appendChild(document.createTextNode(result[i].Serie + " - Season : " + result[i].SeasonNumber + " - Ep : " + result[i].EpisodeNumber));
+                    label.appendChild(span);
+
+                    var button = document.createElement("button");
+                    button.setAttribute("type", "button");
+                    button.id = result[i].Serie;
+                    button.setAttribute("season", result[i].SeasonNumber);
+                    button.setAttribute("onclick", "MyAnimeSyncConfig.deleteFailedEntry(this.id, this.getAttribute('season'))");
+
+                    button.textContent = "Delete";
+                    label.appendChild(button);
+
+                    br = document.createElement("br");
+                    label.append(br);
+
+                    div.appendChild(label);
+                }
             },
 
             populateOptionsContainer: async function (userConfig) {
@@ -156,6 +189,20 @@
                         passwordInput.value = userConfig[key];
                     }
                 }
+            },
+
+            deleteFailedEntry: async function (serie, season)
+            {
+                console.log("Deleting this : " + serie + " / season : " + season);
+
+                var guid = MyAnimeSyncConfig.userSelector.value;
+                uConfig = MyAnimeSyncConfig.configCache.UserConfigs.filter(e => e.Id === guid)[0];
+                uConfig.FailedUpdates = uConfig.FailedUpdates.filter(item => !(item.Serie == serie && item.SeasonNumber == season));
+
+                console.log(uConfig.FailedUpdates);
+
+                await MyAnimeSyncConfig.saveConfig(guid);
+                await this.loadConfig(MyAnimeSyncConfig.userSelector.value, null);
             },
 
             // This create an empty user config in cache if it does not already exists.

--- a/Jellyfin.Plugin.MyAnimeSync/Configuration/configPage.html
+++ b/Jellyfin.Plugin.MyAnimeSync/Configuration/configPage.html
@@ -153,14 +153,25 @@
                     span.appendChild(document.createTextNode(result[i].Serie + " - Season : " + result[i].SeasonNumber + " - Ep : " + result[i].EpisodeNumber));
                     label.appendChild(span);
 
-                    var button = document.createElement("button");
-                    button.setAttribute("type", "button");
-                    button.id = result[i].Serie;
-                    button.setAttribute("season", result[i].SeasonNumber);
-                    button.setAttribute("onclick", "MyAnimeSyncConfig.deleteFailedEntry(this.id, this.getAttribute('season'))");
+                    // Create retry button for failed update entry
+                    var retryButton = document.createElement("button");
+                    retryButton.setAttribute("type", "button");
+                    retryButton.id = result[i].Serie;
+                    retryButton.setAttribute("season", result[i].SeasonNumber);
+                    retryButton.setAttribute("episode", result[i].EpisodeNumber);
+                    retryButton.style.marginRight = "10px";
+                    retryButton.setAttribute("onclick", "MyAnimeSyncConfig.retryUpdate(this.id, this.getAttribute('season'), this.getAttribute('episode'))");
+                    retryButton.textContent = "Retry";
+                    label.appendChild(retryButton);
 
-                    button.textContent = "Delete";
-                    label.appendChild(button);
+                    // Create delete button for failed update entry
+                    var deleteButton = document.createElement("button");
+                    deleteButton.setAttribute("type", "button");
+                    deleteButton.id = result[i].Serie;
+                    deleteButton.setAttribute("season", result[i].SeasonNumber);
+                    deleteButton.setAttribute("onclick", "MyAnimeSyncConfig.deleteFailedEntry(this.id, this.getAttribute('season'))");
+                    deleteButton.textContent = "Delete";
+                    label.appendChild(deleteButton);
 
                     br = document.createElement("br");
                     label.append(br);
@@ -203,6 +214,23 @@
 
                 await MyAnimeSyncConfig.saveConfig(guid);
                 await this.loadConfig(MyAnimeSyncConfig.userSelector.value, null);
+            },
+
+            retryUpdate: async function (serie, season, ep)
+            {
+                console.log("Retrying to update entry : " + serie + " - season : " + season + " - ep : " + ep);
+                var baseUrl = document.getElementById("jellyfinUrl").value;
+                var guid = MyAnimeSyncConfig.userSelector.value
+                await fetch(baseUrl + "/MyAnimeSync/retryUpdate?guid=" + guid + "&serie=" + serie + "&season=" + season + "&episode=" + ep)
+                        .then((response) => response.json())
+                        .then((json) => {
+                            console.log(json);
+                            if (json)
+                            {
+                                window.ApiClient.getPluginConfiguration(MyAnimeSyncConfig.guid).then(MyAnimeSyncConfig.loadConfig.bind(MyAnimeSyncConfig, MyAnimeSyncConfig.userSelector.value));
+                            }
+                        }
+                );
             },
 
             // This create an empty user config in cache if it does not already exists.

--- a/Jellyfin.Plugin.MyAnimeSync/Service/OnMarkedService.cs
+++ b/Jellyfin.Plugin.MyAnimeSync/Service/OnMarkedService.cs
@@ -95,6 +95,118 @@ namespace Jellyfin.Plugin.MyAnimeSync.Service
         /// <summary>
         /// Update anime watch list on MyAnimeList when an episode is marked as watched.
         /// </summary>
+        /// <param name="serie">The serie's name.<see cref="string"/>.</param>
+        /// <param name="episodeNumber">The episode number.<see cref="int"/>.</param>
+        /// <param name="seasonNumber">The season number.<see cref="int"/>.</param>
+        /// <param name="userConfig">The user config. <see cref="UserConfig"/>.</param>
+        /// <returns> The task. </returns>
+        public async Task<bool> UpdateAnimeList(string serie, int episodeNumber, int? seasonNumber, UserConfig userConfig)
+        {
+            // Update tokens if needed before using the api.
+            await MalApiHandler.RefreshTokens(userConfig).ConfigureAwait(true);
+
+            int? id = await MalApiHandler.GetAnimeID(serie, userConfig).ConfigureAwait(true);
+            if (id == null)
+            {
+                _logger.LogError(
+                    "Could not retrieve id for anime : {AnimeName}",
+                    serie);
+                return false;
+            }
+
+            AnimeData? info = await MalApiHandler.GetAnimeInfo(id.Value, userConfig).ConfigureAwait(true);
+            if (info == null || info.ID == null || info.EpisodeCount == null)
+            {
+                _logger.LogError(
+                    "Could not retrieve anime info for id : {ID}",
+                    id);
+                return false;
+            }
+
+            int seasonOffset = seasonNumber - 1 ?? 0;
+
+            // If we have a specified anime season.
+            while (seasonOffset > 0)
+            {
+                info = await GetAnimeSequel(info, userConfig).ConfigureAwait(true);
+                if (info == null || info.ID == null || info.EpisodeCount == null || info.Title == null || info.MediaType == null)
+                {
+                    _logger.LogError(
+                        "Could not retrieve expected sequel using season offset for anime : {ID}",
+                        id);
+                    return false;
+                }
+
+                // Ignore anime movie for season offset.
+                if (info.MediaType == MediaType.Movie)
+                {
+                    continue;
+                }
+
+                Regex expression = new Regex(".*part ([0-9]+).*", RegexOptions.IgnoreCase);
+                Match match = expression.Match(info.Title);
+                if (match.Success)
+                {
+                    int partNumber;
+                    _ = int.TryParse(match.Groups[1].Value, out partNumber);
+                    if (partNumber > 1)
+                    {
+                        continue;
+                    }
+                }
+
+                seasonOffset--;
+            }
+
+            // If episode is > expect max season episode, we try to find the proper season.
+            // Also if the number of episodes is unknown, result is 0. So treat it as being the proper anime season.
+            while (info.EpisodeCount > 0 && info.EpisodeCount < episodeNumber)
+            {
+                episodeNumber -= info.EpisodeCount.Value;
+                info = await GetAnimeSequel(info, userConfig).ConfigureAwait(true);
+                if (info == null || info.ID == null || info.EpisodeCount == null)
+                {
+                    _logger.LogError(
+                        "Could not retrieve expected sequel using episode offset for anime : {ID}",
+                        id);
+                    return false;
+                }
+            }
+
+            // Retrieve anime status in user library.
+            UserAnimeInfo entry = await MalApiHandler.GetUserAnimeInfo(info.ID.Value, userConfig).ConfigureAwait(true);
+            if (!entry.SuccessStatus)
+            {
+                _logger.LogError(
+                        "Could not parse anime list for user : {User}",
+                        userConfig.Id);
+                return false;
+            }
+
+            if (entry.Info != null && entry.Info.StatusInfo != null)
+            {
+                // Do nothing if anime is already marked as completed or if the episode number is not higher then the user watched episode.
+                if (entry.Info.StatusInfo.Status == WatchStatus.Completed || entry.Info.StatusInfo.EpisodeWatched >= episodeNumber)
+                {
+                    _logger.LogInformation("No need to update user entry for anime : {Anime} season {Season} ep {Ep}", serie, seasonNumber, entry.Info.StatusInfo.EpisodeWatched);
+                    return true;
+                }
+            }
+
+            string status = WatchStatus.Watching;
+            if (info.EpisodeCount > 0 && episodeNumber >= info.EpisodeCount)
+            {
+                status = WatchStatus.Completed;
+            }
+
+            // Update anime status
+            MalApiHandler.UpdateUserInfo(info.ID.Value, episodeNumber, status, userConfig);
+            return true;
+        }
+
+        /// <summary>
+        /// Update anime watch list on MyAnimeList when an episode is marked as watched.
+        /// </summary>
         /// <param name="sender">Sender.<see cref="object"/>.</param>
         /// <param name="eventArgs">Informations about the event.<see cref="UserDataSaveEventArgs"/>.</param>
         private async void OnUserDataMarkedPlayed(object? sender, UserDataSaveEventArgs eventArgs)
@@ -113,8 +225,6 @@ namespace Jellyfin.Plugin.MyAnimeSync.Service
                     return;
                 }
 
-                // Update tokens if needed before using the api.
-                await MalApiHandler.RefreshTokens(userConfig).ConfigureAwait(true);
                 if (eventArgs.Item is Episode episode)
                 {
                     string serie = episode.SeriesName;
@@ -133,15 +243,6 @@ namespace Jellyfin.Plugin.MyAnimeSync.Service
                         return;
                     }
 
-                    int? id = await MalApiHandler.GetAnimeID(serie, userConfig).ConfigureAwait(true);
-                    if (id == null)
-                    {
-                        _logger.LogError(
-                            "Could not retrieve id for anime : {AnimeName}",
-                            serie);
-                        return;
-                    }
-
                     int? episodeNumber = episode.IndexNumber;
                     if (episodeNumber == null)
                     {
@@ -151,93 +252,7 @@ namespace Jellyfin.Plugin.MyAnimeSync.Service
                         return;
                     }
 
-                    AnimeData? info = await MalApiHandler.GetAnimeInfo(id.Value, userConfig).ConfigureAwait(true);
-                    if (info == null || info.ID == null || info.EpisodeCount == null)
-                    {
-                        _logger.LogError(
-                            "Could not retrieve anime info for id : {ID}",
-                            id);
-                        return;
-                    }
-
-                    int seasonOffset = episode.AiredSeasonNumber - 1 ?? 0;
-
-                    // If we have a specified anime season.
-                    while (seasonOffset > 0)
-                    {
-                        info = await GetAnimeSequel(info, userConfig).ConfigureAwait(true);
-                        if (info == null || info.ID == null || info.EpisodeCount == null || info.Title == null || info.MediaType == null)
-                        {
-                            _logger.LogError(
-                                "Could not retrieve expected sequel using season offset for anime : {ID}",
-                                id);
-                            return;
-                        }
-
-                        // Ignore anime movie for season offset.
-                        if (info.MediaType == MediaType.Movie)
-                        {
-                            continue;
-                        }
-
-                        Regex expression = new Regex(".*part ([0-9]+).*", RegexOptions.IgnoreCase);
-                        Match match = expression.Match(info.Title);
-                        if (match.Success)
-                        {
-                            int partNumber;
-                            _ = int.TryParse(match.Groups[1].Value, out partNumber);
-                            if (partNumber > 1)
-                            {
-                                continue;
-                            }
-                        }
-
-                        seasonOffset--;
-                    }
-
-                    // If episode is > expect max season episode, we try to find the proper season.
-                    // Also if the number of episodes is unknown, result is 0. So treat it as being the proper anime season.
-                    while (info.EpisodeCount > 0 && info.EpisodeCount < episodeNumber)
-                    {
-                        episodeNumber -= info.EpisodeCount;
-                        info = await GetAnimeSequel(info, userConfig).ConfigureAwait(true);
-                        if (info == null || info.ID == null || info.EpisodeCount == null)
-                        {
-                            _logger.LogError(
-                                "Could not retrieve expected sequel using episode offset for anime : {ID}",
-                                id);
-                            return;
-                        }
-                    }
-
-                    // Retrieve anime status in user library.
-                    UserAnimeInfo entry = await MalApiHandler.GetUserAnimeInfo(info.ID.Value, userConfig).ConfigureAwait(true);
-                    if (!entry.SuccessStatus)
-                    {
-                        _logger.LogError(
-                                "Could not parse anime list for user : {User}",
-                                userID);
-                        return;
-                    }
-
-                    if (entry.Info != null && entry.Info.StatusInfo != null)
-                    {
-                        // Do nothing if anime is already marked as completed or if the episode number is not higher then the user watched episode.
-                        if (entry.Info.StatusInfo.Status == WatchStatus.Completed || entry.Info.StatusInfo.EpisodeWatched >= episodeNumber.Value)
-                        {
-                            _logger.LogInformation("No need to update user entry for anime : {Anime} season {Season} ep {Ep}", serie, episode.AiredSeasonNumber, entry.Info.StatusInfo.EpisodeWatched);
-                            return;
-                        }
-                    }
-
-                    string status = WatchStatus.Watching;
-                    if (info.EpisodeCount > 0 && episodeNumber >= info.EpisodeCount)
-                    {
-                        status = WatchStatus.Completed;
-                    }
-
-                    // Update anime status
-                    MalApiHandler.UpdateUserInfo(info.ID.Value, episodeNumber.Value, status, userConfig);
+                    bool success = await UpdateAnimeList(serie, episodeNumber.Value, episode.AiredSeasonNumber, userConfig).ConfigureAwait(true);
                 }
             }
         }


### PR DESCRIPTION
Added an interactive list of failed updates to the plugin config page.
It allows you to force retry updating entries that failed and deleting a failed entry from the daily retry list. (Capped at 5 retry per episode for automatic daily retry to avoid excessive API use)

The main goal of this feature is to avoid missing anime update if the MAL website/api is down when we try to update the user list.
It also permit retrying to update failed entries after updating the search algorithm without having to manually mark the episode in the user's library. The goal is to avoid having to manually update the user anime list in cases where the plugin misses an anime list update.