### PR TITLE
refactor/correct_user_config_client_id_and_secret_before_generating_a…

### DIFF
--- a/Jellyfin.Plugin.MyAnimeSync/Api/MALS/malApiHandler.cs
+++ b/Jellyfin.Plugin.MyAnimeSync/Api/MALS/malApiHandler.cs
@@ -59,6 +59,20 @@ namespace Jellyfin.Plugin.MyAnimeSync.Api.Mal
                 return null;
             }
 
+            // Remove all non alphanumeric characters from the ClientID.
+            if (!uConfig.ClientID.All(char.IsLetterOrDigit))
+            {
+                uConfig.ClientID = new string(uConfig.ClientID.Where(c => char.IsLetterOrDigit(c)).ToArray());
+                Plugin.Instance?.SaveConfiguration();
+            }
+
+            // Remove all non alphanumeric characters from the ClientSecret.
+            if (!uConfig.ClientSecret.All(char.IsLetterOrDigit))
+            {
+                uConfig.ClientSecret = new string(uConfig.ClientSecret.Where(c => char.IsLetterOrDigit(c)).ToArray());
+                Plugin.Instance?.SaveConfiguration();
+            }
+
             return $"{AuthorisationUrl}?response_type=code&client_id={uConfig.ClientID}&code_challenge={codeChallenge}";
         }
 


### PR DESCRIPTION
Removing spaces and special characters that can be introduced when manually selecting client id and client secret using the mouse.

Related to #22 
Related to #34 