### PR TITLE
refactor/first_unit_tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,5 +14,24 @@ on:
   workflow_dispatch:
 
 jobs:
-  call:
-    uses: jellyfin/jellyfin-meta-plugins/.github/workflows/test.yaml@master
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+        with:
+          dotnet-version: "9.0.x"
+
+      - name: Install dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test --no-restore --verbosity normal
+        env:
+          MAL_ACCESS_TOKEN: ${{ secrets.MAL_ACCESS_TOKEN }}

--- a/Jellyfin.Plugin.MyAnimeSync/Jellyfin.Plugin.MyAnimeSync.csproj
+++ b/Jellyfin.Plugin.MyAnimeSync/Jellyfin.Plugin.MyAnimeSync.csproj
@@ -22,6 +22,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>MyAnimeSync.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <None Remove="Configuration\configPage.html" />
     <EmbeddedResource Include="Configuration\configPage.html" />
   </ItemGroup>

--- a/Jellyfin.Plugin.MyAnimeSync/Service/OnMarkedService.cs
+++ b/Jellyfin.Plugin.MyAnimeSync/Service/OnMarkedService.cs
@@ -5,6 +5,7 @@ using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.MyAnimeSync.Api.Mal;
 using Jellyfin.Plugin.MyAnimeSync.Api.TVDB;
 using Jellyfin.Plugin.MyAnimeSync.Configuration;
@@ -155,30 +156,24 @@ namespace Jellyfin.Plugin.MyAnimeSync.Service
             }
         }
 
-        private static async Task<bool> InternalUpdateAnimeList(string serie, int episodeNumber, int? seasonNumber, UserConfig userConfig, ILogger logger)
+        internal static AnimeData? InternalRetrieveAnimeData(string serie, ref int episodeNumber, int? seasonNumber, UserConfig userConfig, ILogger logger)
         {
-            // Update tokens if needed before using the api.
-            if (!await MalApiHandler.RefreshTokens(userConfig).ConfigureAwait(true))
-            {
-                logger.LogError("Could not update token for user: {UserID}", userConfig.Id);
-            }
-
-            int? id = await MalApiHandler.GetAnimeID(serie, userConfig).ConfigureAwait(true);
+            int? id = MalApiHandler.GetAnimeID(serie, userConfig).Result;
             if (id == null)
             {
                 logger.LogError(
                     "Could not retrieve id for anime : {AnimeName}",
                     serie);
-                return false;
+                return null;
             }
 
-            AnimeData? info = await MalApiHandler.GetAnimeInfo(id.Value, userConfig).ConfigureAwait(true);
+            AnimeData? info = MalApiHandler.GetAnimeInfo(id.Value, userConfig).Result;
             if (info == null || info.ID == null || info.EpisodeCount == null)
             {
                 logger.LogError(
                     "Could not retrieve anime info for id : {ID}",
                     id);
-                return false;
+                return null;
             }
 
             int seasonOffset = seasonNumber - 1 ?? 0;
@@ -186,7 +181,7 @@ namespace Jellyfin.Plugin.MyAnimeSync.Service
             // If we have a specified anime season.
             while (seasonOffset > 0)
             {
-                info = await GetAnimeSequel(info, userConfig, logger).ConfigureAwait(true);
+                info = GetAnimeSequel(info, userConfig, logger).Result;
                 if (info == null || info.ID == null || info.EpisodeCount == null || info.Title == null || info.MediaType == null || info.AlternativeTitles == null || info.AlternativeTitles.EnglishTitle == null)
                 {
                     logger.LogError(
@@ -195,7 +190,7 @@ namespace Jellyfin.Plugin.MyAnimeSync.Service
 
                     // TODO: Check if we can try to find the absolute episode number instead of the season number. (For anime like one piece)
                     // int? tvdbID = await TVDBApiHandler.GetSerieID(serie).ConfigureAwait(true);
-                    return false;
+                    return null;
                 }
 
                 // Ignore anime movie for season offset.
@@ -237,20 +232,42 @@ namespace Jellyfin.Plugin.MyAnimeSync.Service
             while (info.EpisodeCount > 0 && info.EpisodeCount < episodeNumber)
             {
                 episodeNumber -= info.EpisodeCount.Value;
-                info = await GetAnimeSequel(info, userConfig, logger).ConfigureAwait(true);
+                info = GetAnimeSequel(info, userConfig, logger).Result;
                 if (info == null || info.ID == null || info.EpisodeCount == null)
                 {
                     logger.LogError(
                         "Could not retrieve expected sequel using episode offset for anime : {ID}",
                         id);
-                    return false;
+                    return null;
                 }
+            }
+
+            return info;
+        }
+
+        internal static async Task<bool> InternalUpdateAnimeList(string serie, int episodeNumber, int? seasonNumber, UserConfig userConfig, ILogger logger)
+        {
+            // Update tokens if needed before using the api.
+            if (!await MalApiHandler.RefreshTokens(userConfig).ConfigureAwait(true))
+            {
+                logger.LogError("Could not update token for user: {UserID}", userConfig.Id);
+            }
+
+            AnimeData? info = null;
+            await Task.Run(() =>
+            {
+                info = InternalRetrieveAnimeData(serie, ref episodeNumber, seasonNumber, userConfig, logger);
+            }).ConfigureAwait(true);
+
+            if (info == null)
+            {
+                return false;
             }
 
             return UpdateUserList(serie, episodeNumber, seasonNumber, info, userConfig, logger);
         }
 
-        private static async Task<bool> InternalUpdateAnimeListSpecial(string serie, int episodeNumber, UserConfig userConfig, ILogger logger)
+        internal static async Task<bool> InternalUpdateAnimeListSpecial(string serie, int episodeNumber, UserConfig userConfig, ILogger logger)
         {
             if (!userConfig.AllowSpecials)
             {

--- a/MyAnimeSync.Tests/MyAnimeSync.Tests.csproj
+++ b/MyAnimeSync.Tests/MyAnimeSync.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Jellyfin.Plugin.MyAnimeSync\Jellyfin.Plugin.MyAnimeSync.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/MyAnimeSync.Tests/TestUserListUpdate.cs
+++ b/MyAnimeSync.Tests/TestUserListUpdate.cs
@@ -1,0 +1,80 @@
+﻿using Jellyfin.Plugin.MyAnimeSync.Api.Mal;
+using Jellyfin.Plugin.MyAnimeSync.Configuration;
+using Jellyfin.Plugin.MyAnimeSync.Service;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace MyAnimeSync.Tests;
+
+public class TestUserListUpdate
+{
+    private readonly string _accessToken;
+    private ILogger<TestUserListUpdate> _logger = new NullLogger<TestUserListUpdate>();
+
+    public TestUserListUpdate()
+    {
+        _accessToken = Environment.GetEnvironmentVariable("MAL_ACCESS_TOKEN")
+            ?? throw new InvalidOperationException("MAL_ACCESS_TOKEN is not set.");
+    }
+
+    // Most basic test, retrieve the anime without any season logic.
+    [Fact]
+    public async Task TestBasicUpdate()
+    {
+        UserConfig userConfig = new UserConfig();
+
+        userConfig.UserToken = _accessToken;
+
+        UpdateEntry entry = new UpdateEntry("Demon Slayer", "Kimetsu no Yaiba", 8, 1);
+        bool result = await OnMarkedService.UpdateAnimeList(entry, userConfig, _logger);
+        Assert.True(result);
+    }
+
+    // Test for generic anime tagged with the proper season.
+    [Fact]
+    public async Task TestUpdateWithSeason()
+    {
+        UserConfig userConfig = new UserConfig();
+
+        userConfig.UserToken = _accessToken;
+
+        int episodeNumber = 8;
+        AnimeData? info = OnMarkedService.InternalRetrieveAnimeData("Demon Slayer", ref episodeNumber, 2, userConfig, _logger);
+        Assert.NotNull(info);
+        Assert.NotNull(info.ID);
+        Assert.Equal(47778, info.ID);
+    }
+
+    // Test season search using absolute episode.
+    // This test also check for anime with multiple sequel type. (movie vs tv serie)
+    [Fact]
+    public void TestUpdateWithSeasonOffset()
+    {
+        UserConfig userConfig = new UserConfig();
+
+        userConfig.UserToken = _accessToken;
+
+        int episodeNumber = 60;
+        AnimeData? info = OnMarkedService.InternalRetrieveAnimeData("Demon Slayer", ref episodeNumber, 1, userConfig, _logger);
+        Assert.NotNull(info);
+        Assert.NotNull(info.ID);
+        Assert.Equal(55701, info.ID);
+        Assert.Equal(5, episodeNumber);
+    }
+
+    // Test for season with parts
+    [Fact]
+    public void TestUpdateWithSeasonParts()
+    {
+        UserConfig userConfig = new UserConfig();
+
+        userConfig.UserToken = _accessToken;
+
+        UpdateEntry entry = new UpdateEntry("Re:ZERO -Starting Life in Another World-", "Re:Zero kara Hajimeru Isekai Seikatsu", 2, 3);
+        int episodeNumber = 2;
+        AnimeData? info = OnMarkedService.InternalRetrieveAnimeData("Re:ZERO -Starting Life in Another World-", ref episodeNumber, 3, userConfig, _logger);
+        Assert.NotNull(info);
+        Assert.NotNull(info.ID);
+        Assert.Equal(54857, info.ID);
+    }
+}

--- a/MyAnimeSync.sln
+++ b/MyAnimeSync.sln
@@ -1,20 +1,46 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.5.002.0
+VisualStudioVersion = 17.5.2.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Jellyfin.Plugin.MyAnimeSync", "Jellyfin.Plugin.MyAnimeSync\Jellyfin.Plugin.MyAnimeSync.csproj", "{7BA1BEA6-EEF7-4E52-8FB7-7EE8E97A3AB9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyAnimeSync.Tests", "MyAnimeSync.Tests\MyAnimeSync.Tests.csproj", "{5A623708-3220-4B87-8757-F1EDB9E113BF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{7BA1BEA6-EEF7-4E52-8FB7-7EE8E97A3AB9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7BA1BEA6-EEF7-4E52-8FB7-7EE8E97A3AB9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7BA1BEA6-EEF7-4E52-8FB7-7EE8E97A3AB9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7BA1BEA6-EEF7-4E52-8FB7-7EE8E97A3AB9}.Debug|x64.Build.0 = Debug|Any CPU
+		{7BA1BEA6-EEF7-4E52-8FB7-7EE8E97A3AB9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7BA1BEA6-EEF7-4E52-8FB7-7EE8E97A3AB9}.Debug|x86.Build.0 = Debug|Any CPU
 		{7BA1BEA6-EEF7-4E52-8FB7-7EE8E97A3AB9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7BA1BEA6-EEF7-4E52-8FB7-7EE8E97A3AB9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7BA1BEA6-EEF7-4E52-8FB7-7EE8E97A3AB9}.Release|x64.ActiveCfg = Release|Any CPU
+		{7BA1BEA6-EEF7-4E52-8FB7-7EE8E97A3AB9}.Release|x64.Build.0 = Release|Any CPU
+		{7BA1BEA6-EEF7-4E52-8FB7-7EE8E97A3AB9}.Release|x86.ActiveCfg = Release|Any CPU
+		{7BA1BEA6-EEF7-4E52-8FB7-7EE8E97A3AB9}.Release|x86.Build.0 = Release|Any CPU
+		{5A623708-3220-4B87-8757-F1EDB9E113BF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5A623708-3220-4B87-8757-F1EDB9E113BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5A623708-3220-4B87-8757-F1EDB9E113BF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5A623708-3220-4B87-8757-F1EDB9E113BF}.Debug|x64.Build.0 = Debug|Any CPU
+		{5A623708-3220-4B87-8757-F1EDB9E113BF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5A623708-3220-4B87-8757-F1EDB9E113BF}.Debug|x86.Build.0 = Debug|Any CPU
+		{5A623708-3220-4B87-8757-F1EDB9E113BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5A623708-3220-4B87-8757-F1EDB9E113BF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5A623708-3220-4B87-8757-F1EDB9E113BF}.Release|x64.ActiveCfg = Release|Any CPU
+		{5A623708-3220-4B87-8757-F1EDB9E113BF}.Release|x64.Build.0 = Release|Any CPU
+		{5A623708-3220-4B87-8757-F1EDB9E113BF}.Release|x86.ActiveCfg = Release|Any CPU
+		{5A623708-3220-4B87-8757-F1EDB9E113BF}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Small changes to the OnMarkedService to allow unit tests to access private (now internal) members.
Isolated anime data retrieval outside of the InternalUpdateAnimeList for better code testability.