### PR TITLE
bug/fix_search_regression_with_unidentified_season_number

### DIFF
--- a/Jellyfin.Plugin.MyAnimeSync/Service/OnMarkedService.cs
+++ b/Jellyfin.Plugin.MyAnimeSync/Service/OnMarkedService.cs
@@ -430,7 +430,7 @@ namespace Jellyfin.Plugin.MyAnimeSync.Service
                         return;
                     }
 
-                    if (episode.IndexNumber == null || episode.AiredSeasonNumber == null)
+                    if (episode.IndexNumber == null)
                     {
                         _logger.LogError(
                             "Could not retrieve episode number for : {AnimeName}",
@@ -438,7 +438,7 @@ namespace Jellyfin.Plugin.MyAnimeSync.Service
                         return;
                     }
 
-                    UpdateEntry entry = new UpdateEntry(episode.SeriesName, episode.Series.OriginalTitle ?? string.Empty, episode.IndexNumber.Value, episode.AiredSeasonNumber.Value);
+                    UpdateEntry entry = new UpdateEntry(episode.SeriesName, episode.Series.OriginalTitle ?? string.Empty, episode.IndexNumber.Value, episode.AiredSeasonNumber ?? 1);
                     await UpdateAnimeList(entry, userConfig, _logger).ConfigureAwait(false);
                 }
             }


### PR DESCRIPTION
Added a check for the aired season that prevent searching for anime when season is not identified.
(May break absolute episode search in some cases)
Reverted this check back to previous behavior, unidentified season treated as first season.
